### PR TITLE
Modified the path of redirecting for squidclamav blocked page

### DIFF
--- a/root/etc/e-smith/templates/etc/squidclamav.conf/20redirect
+++ b/root/etc/e-smith/templates/etc/squidclamav.conf/20redirect
@@ -4,7 +4,5 @@
     my $ndb = esmith::NetworksDB->open_ro();
     my $green = $ndb->green();
     my $redirect = "http://".$green->prop('ipaddr')."/cgi-bin/nethserver-block.cgi"; 
-    $OUT.="        redirect     $redirect\n";
-
-    #$OUT.="redirect http://$SystemName.$DomainName/cgi-bin/nethserver-block.cgi\n";
+    $OUT.="redirect $redirect\n";
 }


### PR DESCRIPTION
Redirect to new file named nethserver-block in squidguard repo to unified the process of blocking pages.
