### PR TITLE
Revert "Restart clamd instance on nethserver-antivirus-update"

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -44,10 +44,3 @@ event_services($event, 'squid' => 'reload');
 $event = "nethserver-squidguard-save";
 templates2events("/etc/squidclamav.conf",  $event);
 event_services($event, 'c-icap' => 'restart');
-
-#--------------------------------------------------
-# actions for nethserver-antivirus-update event
-#--------------------------------------------------
-
-$event = "nethserver-antivirus-update";
-event_services($event, 'clamd@squidclamav' => 'restart');


### PR DESCRIPTION
This reverts commit 2ad6658da0561920e8ace3462eacffc7e167bbc9.

Restart logic is now implemented inside NethServer/nethserver-antivirus#5

NethServer/dev#5803