### PR TITLE
Expand c-icap.conf with nethserver-squidclamav-update

### DIFF
--- a/createlinks
+++ b/createlinks
@@ -31,6 +31,7 @@ my $event = "nethserver-squidclamav-update";
 
 event_actions($event, 'initialize-default-databases' => '00');
 event_actions($event, 'nethserver-squidclamav-conf' => '20');
+templates2events("/etc/c-icap/c-icap.conf",  $event);
 templates2events("/etc/c-icap/squidclamav.conf",  $event);
 templates2events("/etc/squid/squid.conf",  $event);
 event_services($event, 'c-icap' => 'restart');


### PR DESCRIPTION
The template /etc/c-icap/c-icap.conf is not expanded with nethserver-squidclamav-update

https://github.com/NethServer/dev/issues/6569